### PR TITLE
Handling non valid image urls

### DIFF
--- a/src/OpenGraph.php
+++ b/src/OpenGraph.php
@@ -81,6 +81,10 @@ class OpenGraph
 
     protected function verify_image_url($url)
     {
+        if (!filter_var($url, FILTER_VALIDATE_URL)) {
+            return false;
+        }
+
         $headers = get_headers($url);
 
         return stripos($headers[0], '200 OK') ? true : false;

--- a/tests/OpenGraphTest.php
+++ b/tests/OpenGraphTest.php
@@ -46,4 +46,17 @@ class OpenGraphTest extends TestCase
 
         $this->assertEmpty($data);
     }
+
+    /** @test */
+    public function testFetchMustacheMetasData()
+    {
+        $opengraph = new OpenGraph();
+        $data = $opengraph->fetch(
+            'https://raw.githubusercontent.com/jurgenbosch/OpenGraph/master/tests/__mocks__/angular-headers.html', true
+        );
+        $this->assertArrayHasKey('title', $data);
+        $this->assertArrayHasKey('description', $data);
+        $this->assertArrayHasKey('image', $data);
+        $this->assertEmpty($data['image']);
+    }
 }

--- a/tests/__mocks__/angular-headers.html
+++ b/tests/__mocks__/angular-headers.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
+<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>         <html xmlns:ng="https://angularjs.org" class="no-js lt-ie9" id="ng-app" data-ng-app="skeletonApp"> <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js" style="height: 100%; background-color: #ffffff;" data-ng-app="skeletonApp"> <!--<![endif]-->
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Example</title>
+    <meta name="description" content="{{ pageDescription }}" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+
+    <meta property="og:title" content="{{ pageTitle }}" />
+    <meta property="og:description" content="{{ pageDescription }}" />
+    <meta property="og:image" content="{{ picturePath }}" />
+
+    <meta name="theme-color" content="{{ themeColor }}">
+    <meta name="msapplication-navbutton-color" content="{{ themeColor }}">
+    <meta name="apple-mobile-web-app-status-bar-style" content="{{ themeColor }}" />
+    <meta name="{{ indexName }}" content="{{ indexContent }}">
+    <link rel="canonical" href="{{ canonicalUrl }}" />
+</head>
+<body>
+    Body here
+</body>
+</html>


### PR DESCRIPTION
In this pull request I added validation for the image header when a non valid URL is provided. 
We encountered this issue when trying to process the headers of an Angular based website which source provides;

`<meta property="og:image" content="{{ picturePath }}" />`

OpenGraph would try to process (getting the headers and returning the status code) {{ picturePath }} which, obviously, fails and results in an error response. 

My change checks if the provided URL is a valid URL (PHP Filter) and if not it will return before it tries to get the headers. 

I ran all PHPUnit tests to verify everything is still working and I added a new test to test with a mustache syntax as image. 