### PR TITLE
Handling the curl_exec()  error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,19 @@ If you do run the package on Laravel 5.5+, package auto-discovery takes care of 
   $language = 'en' // en-US,en;q=0.8,en-GB;q=0.6,es;q=0.4
   $data = OpenGraph::fetch($url, $allMeta, $language);
   ```
+  
+### Exception Handling
+
+The fetch() method, returns a FetchException with aditional data at failure.
+
+  ```
+      try {
+          $data = OpenGraph::fetch($url, true);
+      } catch (shweshi\OpenGraph\Exceptions\FetchException $e) {
+          $message = $e->getMessage();
+          $data = $e->getData();
+      }
+  ```
 
 ### Testing
 

--- a/src/Exceptions/FetchException.php
+++ b/src/Exceptions/FetchException.php
@@ -7,7 +7,7 @@ class FetchException extends \Exception
     public function __construct(
         $message = '',
         $code = 0,
-        Throwable $previous = null,
+        \Throwable $previous = null,
         $data = []
     ) {
         parent::__construct($message, $code, $previous);

--- a/src/Exceptions/FetchException.php
+++ b/src/Exceptions/FetchException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace shweshi\OpenGraph\Exceptions;
+
+class FetchException extends \Exception
+{
+    public function __construct(
+        $message = "",
+        $code = 0,
+        Throwable $previous = null,
+        $data = []
+    ) {
+        parent::__construct($message, $code, $previous);
+        $this->data = $data;
+    }
+
+    public function getData()
+    {
+        return $this->data;
+    }
+}

--- a/src/Exceptions/FetchException.php
+++ b/src/Exceptions/FetchException.php
@@ -5,7 +5,7 @@ namespace shweshi\OpenGraph\Exceptions;
 class FetchException extends \Exception
 {
     private $data;
-    
+        
     public function __construct(
         $message = '',
         $code = 0,

--- a/src/Exceptions/FetchException.php
+++ b/src/Exceptions/FetchException.php
@@ -5,7 +5,7 @@ namespace shweshi\OpenGraph\Exceptions;
 class FetchException extends \Exception
 {
     public function __construct(
-        $message = "",
+        $message = '',
         $code = 0,
         Throwable $previous = null,
         $data = []

--- a/src/Exceptions/FetchException.php
+++ b/src/Exceptions/FetchException.php
@@ -5,7 +5,7 @@ namespace shweshi\OpenGraph\Exceptions;
 class FetchException extends \Exception
 {
     private $data;
-        
+
     public function __construct(
         $message = '',
         $code = 0,

--- a/src/Exceptions/FetchException.php
+++ b/src/Exceptions/FetchException.php
@@ -4,6 +4,8 @@ namespace shweshi\OpenGraph\Exceptions;
 
 class FetchException extends \Exception
 {
+    private $data;
+    
     public function __construct(
         $message = '',
         $code = 0,

--- a/src/OpenGraph.php
+++ b/src/OpenGraph.php
@@ -75,11 +75,11 @@ class OpenGraph
         ]);
 
         $response = curl_exec($curl);
-        if (curl_errno($curl) !== 0) {
-            throw new FetchException(curl_error($curl), curl_errno($curl), null, curl_getinfo($curl));
+        if (curl_errno(/** @scrutinizer ignore-type */ $curl) !== 0) {
+            throw new FetchException(curl_error(/** @scrutinizer ignore-type */ $curl), curl_errno($curl), null, curl_getinfo(/** @scrutinizer ignore-type */ $curl));
         }
 
-        curl_close($curl);
+        curl_close(/** @scrutinizer ignore-type */ $curl);
 
         return $response;
     }

--- a/src/OpenGraph.php
+++ b/src/OpenGraph.php
@@ -75,9 +75,9 @@ class OpenGraph
         ]);
 
         $response = curl_exec($curl);
-        if (curl_errno($curl)!==0){
+        if (curl_errno($curl) !== 0) {
             $message = curl_error($curl);
-            throw new FetchException ($message,curl_errno($curl), null, curl_getinfo($curl));
+            throw new FetchException ($message, curl_errno($curl), null, curl_getinfo($curl));
         }
 
         curl_close($curl);

--- a/src/OpenGraph.php
+++ b/src/OpenGraph.php
@@ -3,6 +3,7 @@
 namespace shweshi\OpenGraph;
 
 use DOMDocument;
+use shweshi\OpenGraph\Exceptions\FetchException;
 
 class OpenGraph
 {
@@ -13,7 +14,7 @@ class OpenGraph
          * parsing starts here:.
          */
         $doc = new DOMDocument();
-        @$doc->loadHTML('<?xml encoding="utf-8" ?>'.$html);
+        $doc->loadHTML('<?xml encoding="utf-8" ?>'.$html);
 
         $tags = $doc->getElementsByTagName('meta');
         $metadata = [];
@@ -60,7 +61,7 @@ class OpenGraph
 
         curl_setopt_array($curl, [
             CURLOPT_URL            => $url,
-            CURLOPT_FAILONERROR    => false,
+            CURLOPT_FAILONERROR    => true,
             CURLOPT_FOLLOWLOCATION => true,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_SSL_VERIFYHOST => false,
@@ -74,6 +75,11 @@ class OpenGraph
         ]);
 
         $response = curl_exec($curl);
+        if (curl_errno($curl)!==0){
+            $message = curl_error($curl);
+            throw new FetchException ($message,curl_errno($curl), null, curl_getinfo($curl));
+        }
+
         curl_close($curl);
 
         return $response;

--- a/src/OpenGraph.php
+++ b/src/OpenGraph.php
@@ -76,9 +76,7 @@ class OpenGraph
 
         $response = curl_exec($curl);
         if (curl_errno($curl) !== 0) {
-            $message = curl_error($curl);
-            
-            throw new FetchException($message, curl_errno($curl), null, curl_getinfo($curl));
+            throw new FetchException(curl_error($curl), curl_errno($curl), null, curl_getinfo($curl));
         }
 
         curl_close($curl);

--- a/src/OpenGraph.php
+++ b/src/OpenGraph.php
@@ -77,6 +77,7 @@ class OpenGraph
         $response = curl_exec($curl);
         if (curl_errno($curl) !== 0) {
             $message = curl_error($curl);
+            
             throw new FetchException($message, curl_errno($curl), null, curl_getinfo($curl));
         }
 

--- a/src/OpenGraph.php
+++ b/src/OpenGraph.php
@@ -77,7 +77,7 @@ class OpenGraph
         $response = curl_exec($curl);
         if (curl_errno($curl) !== 0) {
             $message = curl_error($curl);
-            throw new FetchException ($message, curl_errno($curl), null, curl_getinfo($curl));
+            throw new FetchException($message, curl_errno($curl), null, curl_getinfo($curl));
         }
 
         curl_close($curl);


### PR DESCRIPTION
I lost a lot of time trying to understand why OpenGraph::fetch() was returning empty array on server. Found out that the server's IP was blacklisted by the website I tried to get metadata from.(The curl_error() was returning "The requested URL returned error: 403 Forbidden")
Same method, using same website was working fine on my development machine.
