### PR TITLE
Update OpenGraph.php

### DIFF
--- a/src/OpenGraph.php
+++ b/src/OpenGraph.php
@@ -16,13 +16,14 @@ class OpenGraph
          */
         $doc = new DOMDocument();
 
-        try {
-            $doc->loadHTML('<?xml encoding="utf-8" ?>'.$html);
-        } catch (\Exception $exception) {
-            //catch possible errors due to empty or malformed HTML
-            Log::warning($exception->getMessage());
-        }
-
+        $libxml_previous_state = libxml_use_internal_errors(true);
+        $doc->loadHTML('<?xml encoding="utf-8" ?>'.$html);        
+        //catch possible errors due to empty or malformed HTML
+        Log::warning(libxml_get_errors());
+        libxml_clear_errors();
+        // restore previous state
+        libxml_use_internal_errors($libxml_previous_state);
+        
         $tags = $doc->getElementsByTagName('meta');
         $metadata = [];
         foreach ($tags as $tag) {

--- a/src/OpenGraph.php
+++ b/src/OpenGraph.php
@@ -17,13 +17,13 @@ class OpenGraph
         $doc = new DOMDocument();
 
         $libxml_previous_state = libxml_use_internal_errors(true);
-        $doc->loadHTML('<?xml encoding="utf-8" ?>'.$html);        
+        $doc->loadHTML('<?xml encoding="utf-8" ?>'.$html);
         //catch possible errors due to empty or malformed HTML
         Log::warning(libxml_get_errors());
         libxml_clear_errors();
         // restore previous state
         libxml_use_internal_errors($libxml_previous_state);
-        
+
         $tags = $doc->getElementsByTagName('meta');
         $metadata = [];
         foreach ($tags as $tag) {


### PR DESCRIPTION
using try...catch wasn't best idea since if there are a lot of   DOMDocument::loadHTML() everything gets really slow.

the libxml_use_internal_errors(true) indicates that you're going to handle the errors and warnings ourselves and so they don'to mess up the output / slow down things.

This is not the same as the @ operator. The warnings get collected behind the scenes and afterwards you can retrieve them by using libxml_get_errors() in case you wish to perform logging or return the list of issues to the caller.

Whether or not you're using the collected warnings you should always clear the queue by calling libxml_clear_errors().