### PR TITLE
Log errors from DOMDocument::loadHTML() using libxml_get_errors()

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ If you do run the package on Laravel 5.5+, package auto-discovery takes care of 
   $language = 'en' // en-US,en;q=0.8,en-GB;q=0.6,es;q=0.4
   $data = OpenGraph::fetch($url, $allMeta, $language);
   ```
+  You can also pass additional Libxml parameters as the fourth argument ($options)  https://www.php.net/manual/en/libxml.constants.php. Default options are set to suppress the reporting of errors and warnings 
+  ```
+  $data = OpenGraph::fetch($url, $allMeta, $language, $options);  
+  ```
   
 ### Exception Handling
 

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,9 @@
       "email": "contactmespg@gmail.com"
     }
   ],
-  "require": {},
+  "require": {
+    "illuminate/log": "^5.0|^6.0|^7.0|^8.0"
+  },
   "require-dev": {
     "phpunit/phpunit": "4.8.*"
   },

--- a/src/OpenGraph.php
+++ b/src/OpenGraph.php
@@ -19,7 +19,7 @@ class OpenGraph
         $doc->loadHTML('<?xml encoding="utf-8" ?>'.$html, $options);
         //catch possible errors due to empty or malformed HTML
         if ($options > 0 && ($options & (LIBXML_NOWARNING | LIBXML_NOERROR)) == 0) {
-          Log::warning(libxml_get_errors());
+            Log::warning(libxml_get_errors());
         }
         libxml_clear_errors();
         // restore previous state

--- a/src/OpenGraph.php
+++ b/src/OpenGraph.php
@@ -8,7 +8,7 @@ use shweshi\OpenGraph\Exceptions\FetchException;
 
 class OpenGraph
 {
-    public function fetch($url, $allMeta = null, $lang = null)
+    public function fetch($url, $allMeta = null, $lang = null, $options = LIBXML_NOWARNING | LIBXML_NOERROR)
     {
         $html = $this->curl_get_contents($url, $lang);
         /**
@@ -17,9 +17,11 @@ class OpenGraph
         $doc = new DOMDocument();
 
         $libxml_previous_state = libxml_use_internal_errors(true);
-        $doc->loadHTML('<?xml encoding="utf-8" ?>'.$html);
+        $doc->loadHTML('<?xml encoding="utf-8" ?>'.$html, $options);
         //catch possible errors due to empty or malformed HTML
-        Log::warning(libxml_get_errors());
+        if ($options > 0 && ($options & (LIBXML_NOWARNING | LIBXML_NOERROR)) == 0) {
+          Log::warning(libxml_get_errors());
+        }
         libxml_clear_errors();
         // restore previous state
         libxml_use_internal_errors($libxml_previous_state);


### PR DESCRIPTION
added fourth argument which can be used to pass additional options to LoadHTML() method, including options for suppressing warnings and errors; loadHTML() second argument is 0  (LIBXML_ERR_NONE flag)
#64 