### PR TITLE
Add custom user agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ If you do run the package on Laravel 5.5+, package auto-discovery takes care of 
   ```
   $data = OpenGraph::fetch($url, $allMeta, $language, $options);  
   ```
+  You can use the fifth parameter to set the user-agent ($userAgent) of the request. The default is 'Curl'.
+  ```
+  $data = OpenGraph::fetch($url, $allMeta, $language, $options, $userAgent);  
+  ```
   
 ### Exception Handling
 

--- a/src/OpenGraph.php
+++ b/src/OpenGraph.php
@@ -59,7 +59,7 @@ class OpenGraph
         $headers = [
             'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
             'Cache-Control: no-cache',
-            'User-Agent: ' . $userAgent,
+            'User-Agent: '.$userAgent
         ];
 
         if ($lang) {

--- a/src/OpenGraph.php
+++ b/src/OpenGraph.php
@@ -59,7 +59,7 @@ class OpenGraph
         $headers = [
             'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
             'Cache-Control: no-cache',
-            'User-Agent: '.$userAgent
+            'User-Agent: '.$userAgent,
         ];
 
         if ($lang) {

--- a/src/OpenGraph.php
+++ b/src/OpenGraph.php
@@ -7,7 +7,7 @@ use shweshi\OpenGraph\Exceptions\FetchException;
 
 class OpenGraph
 {
-    public function fetch($url, $allMeta = null, $lang = null, $options = LIBXML_NOWARNING | LIBXML_NOERROR, $userAgent = 'Curl')
+    public function fetch($url, $allMeta = null, $lang = null, $userAgent = 'Curl', $options = LIBXML_NOWARNING | LIBXML_NOERROR)
     {
         $html = $this->curl_get_contents($url, $lang, $userAgent);
         /**

--- a/src/OpenGraph.php
+++ b/src/OpenGraph.php
@@ -7,7 +7,7 @@ use shweshi\OpenGraph\Exceptions\FetchException;
 
 class OpenGraph
 {
-    public function fetch($url, $allMeta = null, $lang = null, $userAgent = 'Curl', $options = LIBXML_NOWARNING | LIBXML_NOERROR)
+    public function fetch($url, $allMeta = null, $lang = null, $options = LIBXML_NOWARNING | LIBXML_NOERROR, $userAgent = 'Curl')
     {
         $html = $this->curl_get_contents($url, $lang, $userAgent);
         /**

--- a/src/OpenGraph.php
+++ b/src/OpenGraph.php
@@ -7,9 +7,9 @@ use shweshi\OpenGraph\Exceptions\FetchException;
 
 class OpenGraph
 {
-    public function fetch($url, $allMeta = null, $lang = null, $options = LIBXML_NOWARNING | LIBXML_NOERROR)
+    public function fetch($url, $allMeta = null, $lang = null, $options = LIBXML_NOWARNING | LIBXML_NOERROR, $userAgent = 'Curl')
     {
-        $html = $this->curl_get_contents($url, $lang);
+        $html = $this->curl_get_contents($url, $lang, $userAgent);
         /**
          * parsing starts here:.
          */
@@ -54,12 +54,12 @@ class OpenGraph
         return $metadata;
     }
 
-    protected function curl_get_contents($url, $lang)
+    protected function curl_get_contents($url, $lang, $userAgent)
     {
         $headers = [
             'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
             'Cache-Control: no-cache',
-            'User-Agent: Curl',
+            'User-Agent: ' . $userAgent,
         ];
 
         if ($lang) {


### PR DESCRIPTION
Uses ```Curl``` as default user agent but adds possibility to specify own user agent. See https://github.com/shweshi/OpenGraph/issues/66