### PR TITLE
Try to process the page even when the server returned 4xx or 5xxx.

### DIFF
--- a/src/OpenGraph.php
+++ b/src/OpenGraph.php
@@ -70,7 +70,7 @@ class OpenGraph
 
         curl_setopt_array($curl, [
             CURLOPT_URL            => $url,
-            CURLOPT_FAILONERROR    => true,
+            CURLOPT_FAILONERROR    => false,
             CURLOPT_FOLLOWLOCATION => true,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_SSL_VERIFYHOST => false,

--- a/tests/OpenGraphTest.php
+++ b/tests/OpenGraphTest.php
@@ -49,6 +49,17 @@ class OpenGraphTest extends TestCase
     }
 
     /** @test */
+    public function testFetchReturnsEmptyArrayForWebsiteWithNoMetadataAndReturnedNotFound()
+    {
+        $opengraph = new OpenGraph();
+        $data = $opengraph->fetch(
+            'https://www.example.com/not-found'
+        );
+
+        $this->assertEmpty($data);
+    }
+
+    /** @test */
     public function testFetchMustacheMetasData()
     {
         $opengraph = new OpenGraph();


### PR DESCRIPTION
Error page may still contain metadata.