### PR TITLE
Add get_meta_value

### DIFF
--- a/src/OpenGraph.php
+++ b/src/OpenGraph.php
@@ -31,11 +31,11 @@ class OpenGraph
             $metaproperty = ($tag->hasAttribute('property')) ? $tag->getAttribute('property') : $tag->getAttribute('name');
             if (!$allMeta && $metaproperty && strpos($tag->getAttribute('property'), 'og:') === 0) {
                 $key = strtr(substr($metaproperty, 3), '-', '_');
-                $value = $tag->getAttribute('content');
+                $value = $this->get_meta_value($tag);
             }
             if ($allMeta && $metaproperty) {
                 $key = (strpos($metaproperty, 'og:') === 0) ? strtr(substr($metaproperty, 3), '-', '_') : $metaproperty;
-                $value = $tag->getAttribute('content');
+                $value = $this->get_meta_value($tag);
             }
             if (!empty($key)) {
                 $metadata[$key] = $value;
@@ -109,5 +109,18 @@ class OpenGraph
         } catch (\Exception $e) {
             return false;
         }
+    }
+
+    protected function get_meta_value($tag)
+    {
+        if (!empty($tag->getAttribute('content'))) {
+            $value = $tag->getAttribute('content');
+        } elseif (!empty($tag->getAttribute('value'))) {
+            $value = $tag->getAttribute('value');
+        } else {
+            $value = '';
+        }
+
+        return $value;
     }
 }


### PR DESCRIPTION
Some meta tag may use value instead of content property

Added `get_meta_value` to handle this kind of case, also when both content nor value property is present, will return null

Example case of meta value property:
Medium read time meta data
```
<meta data-rh="true" name="twitter:label1" value="Reading time" />
<meta data-rh="true" name="twitter:data1" value="3 min read" />
```