### PR TITLE
Fix a problem where the header only contains 200

### DIFF
--- a/src/OpenGraph.php
+++ b/src/OpenGraph.php
@@ -111,7 +111,7 @@ class OpenGraph
             ]);
             $headers = get_headers($url, true, $context_headers);
 
-            return stripos($headers[0], '200 OK') ? true : false;
+            return stripos($headers[0], '200') ? true : false;
         } catch (\Exception $e) {
             return false;
         }

--- a/src/OpenGraph.php
+++ b/src/OpenGraph.php
@@ -111,7 +111,7 @@ class OpenGraph
             ]);
             $headers = get_headers($url, true, $context_headers);
 
-            return stripos($headers[0], '200') ? true : false;
+            return stripos($headers[0], '200') !== false;
         } catch (\Exception $e) {
             return false;
         }


### PR DESCRIPTION
I got this as a response, but still would be valid:

```
HTTP/1.1 200 
```

Can you take a look and merge this @shweshi 